### PR TITLE
check if RequestRate return empty response

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,19 +170,19 @@ func main() {
 
 				body, err := ioutil.ReadAll(resp.Body)
 				if err != nil {
-					log.Error().Err(err).Msgf("Reading prometheus query response body for mig %v failed", configItem.InstanceGroupName)
+					log.Error().Err(err).Msgf("Reading prometheus query (%v) response body for mig %v failed", prometheusQueryURL, configItem.InstanceGroupName)
 					continue
 				}
 
 				queryResponse, err := UnmarshalPrometheusQueryResponse(body)
 				if err != nil {
-					log.Error().Err(err).Msgf("Unmarshalling prometheus query response body for mig %v failed", configItem.InstanceGroupName)
+					log.Error().Err(err).Msgf("Unmarshalling prometheus query (%v) response body for mig %v failed", prometheusQueryURL, configItem.InstanceGroupName)
 					continue
 				}
 
 				requestRate, err := queryResponse.GetRequestRate()
 				if err != nil {
-					log.Error().Err(err).Msgf("Retrieving request rate from query response body for mig %v failed", configItem.InstanceGroupName)
+					log.Error().Err(err).Msgf("Retrieving request rate from query (%v) response body for mig %v failed", prometheusQueryURL, configItem.InstanceGroupName)
 					continue
 				}
 

--- a/prometheus.go
+++ b/prometheus.go
@@ -44,7 +44,10 @@ func UnmarshalPrometheusQueryResponse(responseBody []byte) (queryResponse Promet
 
 // GetRequestRate converts the string value into a float64
 func (pqr *PrometheusQueryResponse) GetRequestRate() (float64, error) {
-	f, err := strconv.ParseFloat(pqr.Data.Result[0].Value[1].(string), 64)
-
+	if len(pqr.Data.Result) > 0 {
+		f, err := strconv.ParseFloat(pqr.Data.Result[0].Value[1].(string), 64)
+	} else {
+		err := "Empty response"
+	}
 	return f, err
 }


### PR DESCRIPTION
**estafette-gcloud-mig-scaler** is restarting when Prometheus query returns an empty result